### PR TITLE
move comment out of sanitize method

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,26 +2,16 @@ module.exports = SingleModuleInstancePlugin;
 
 function SingleModuleInstancePlugin() {}
 
-
 /*
-  Sanitize string strips away the injected webpack header and footer stanzas that
-  are subject to change.
-
-  It does this by first checking for react hot loader in the header,
-  and then the footer. If HMR is found in both, then it grabs the inner
-  module text.
-
+ * Sanitize the source by ignoring webpack require calls:
+ * Say modules 1 & 2 are duplicates of module A
+ *     modules 3 & 4 are duplicates of module B
+ * If module A uses require("B")
+ *    module 1 might contain __webpack_require__(3)
+ *    module 2 might contain __webpack_require__(4)
+ * Stripping the module ids from webpack_require allows to dedupe module 1 and 2.
  */
 function sanitizeString(text) {
-  /*
-   * Sanitize the source by ignoring webpack require calls:
-   * Say modules 1 & 2 are duplicates of module A
-   *     modules 3 & 4 are duplicates of module B
-   * If module A uses require("B")
-   *    module 1 might contain __webpack_require__(3)
-   *    module 2 might contain __webpack_require__(4)
-   * Stripping the module ids from webpack_require allows to dedupe module 1 and 2.
-   */
    return text.replace(/__webpack_require__\(\d+\)/g,"");
 }
 


### PR DESCRIPTION
We should not use /* */ comments in the sanitize function because it gets inlined as shown below:

![image](https://cloud.githubusercontent.com/assets/1141550/21062689/34922bf6-be52-11e6-97bf-8a632a0c2ebc.png)
